### PR TITLE
Fixes to errornous disableCommandHandler check

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -243,7 +243,7 @@ function addCommand(command, callback, suggestion, arguments)
 		commandSuggestions[command] = suggestion
 	end
 
-	if(settings.defaultSettings.disableCommandHandler ~= 'false')then
+	if(settings.defaultSettings.disableCommandHandler == 'false')then
 		RegisterCommand(command, function(source, args)
 			if((#args <= commands[command].arguments and #args == commands[command].arguments) or commands[command].arguments == -1)then
 				callback(source, args, Users[source])
@@ -277,7 +277,7 @@ function addAdminCommand(command, perm, callback, callbackfailed, suggestion, ar
 
 	ExecuteCommand('add_ace group.superadmin command.' .. command .. ' allow')
 
-	if(settings.defaultSettings.disableCommandHandler ~= 'false')then
+	if(settings.defaultSettings.disableCommandHandler == 'false')then
 		RegisterCommand(command, function(source, args)
 			local Source = source
 
@@ -326,7 +326,7 @@ function addGroupCommand(command, group, callback, callbackfailed, suggestion, a
 
 	ExecuteCommand('add_ace group.' .. group .. ' command.' .. command .. ' allow')
 
-	if(settings.defaultSettings.disableCommandHandler ~= 'false')then
+	if(settings.defaultSettings.disableCommandHandler == 'false')then
 		RegisterCommand(command, function(source, args)
 			local Source = source
 


### PR DESCRIPTION
Checks for disableCommandHandler which is a defaultSetting of:
`['disableCommandHandler'] = GetConvar('es_disableCommandHandler', 'false')`

Are being checked incorrectly for multiple commands, making them in effect not work as the check is:
`settings.defaultSettings.disableCommandHandler ~= 'false'`

So to get it to work, you have to:
`es_disableCommandHandler 'true'`

but that breaks too because of the same check in chat:
```
if(settings.defaultSettings.disableCommandHandler ~= 'false')then
	return
end
```

My PR changes the if conditions to be correct.