### PR TITLE
Fix error control when the body response is empty

### DIFF
--- a/server/db.lua
+++ b/server/db.lua
@@ -154,13 +154,17 @@ local function updateDocument(docID, updates, callback)
 			end
 
 			requestDB('PUT', 'essentialmode/' .. docID, doc, {["Content-Type"] = 'application/json'}, function(err, rText, headers)
-				if not json.decode(rText).ok then
-					if err ~= 409 then
-						print(_PrefixError .. 'Error occurred while performing database request: could not update document error ' .. err .. ", returned: " .. rText)
-					end
+				if rText == nil then
+					print(_PrefixError .. 'Error occurred while performing database request: could not update document error ' .. err )
 				else
-					if callback then
-						callback(rText)
+					if not json.decode(rText).ok then
+						if err ~= 409 then
+							print(_PrefixError .. 'Error occurred while performing database request: could not update document error ' .. err .. ", returned: " .. rText)
+						end
+					else
+						if callback then
+							callback(rText)
+						end
 					end
 				end
 			end)


### PR DESCRIPTION
Some times when a error happened when updated document the body responde (rText) come empty so rText is nil, causing a error in fxserver when try json.decode(nil).

i just added a check if rText is nil to show the error in a different way and avoid the fxserver error.

This happened to me using fxserver rev 1971 and couchDB version 3.0.0